### PR TITLE
Shrink images before upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/jest-coverage
 
 # production
 /build

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 
 # testing
 /coverage
-/jest-coverage
 
 # production
 /build

--- a/src/components/NewSpotForm.jsx
+++ b/src/components/NewSpotForm.jsx
@@ -127,10 +127,19 @@ const NewSpotForm = React.memo(({ newSpotLocation, onSubmit, onClose }) => {
                 id="image"
                 name="image"
                 publicKey={process.env.REACT_APP_UPLOADCARE_KEY}
-                onFileSelect={() => setImageUrl(null)}
+                onFileSelect={(file) => {
+                  if (file == null) {
+                    setImageUrl(undefined)
+                  } else {
+                    setImageUrl(null)
+                  }
+                }}
                 onChange={(upload) =>
                   setImageUrl(upload.originalUrl + "-/scale_crop/400x400/")
                 }
+                imageShrink='1600x1600'
+                imagesOnly
+                clearable
               />
             </Box>
           </Stack>


### PR DESCRIPTION
Hey @TransmissionsDev 😀 Nice project

I update little bit widget config
added shrink because some pictures can be bigger then our free plan restriction
made widget clearable, this allows rollback to no image submit.
